### PR TITLE
Update exposure risk level types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -4,19 +4,17 @@ export type AuthorizationStatus =
   | "restricted"
   | "unknown";
 
-// TODO: The values of these constants are INCORRECT.
-// I could not find the actual values online yet.
 // https://developer.apple.com/documentation/exposurenotification/enrisklevel?language=objc
 export const ExposureRiskLevel = {
-  INVALID: -1,
-  LOWEST: 0,
-  LOW: 1,
-  LOW_MEDIUM: 2,
-  MEDIUM: 3,
-  MEDIUM_HIGH: 4,
-  HIGH: 5,
-  VERY_HIGH: 6,
-  HIGHEST: 7,
+  INVALID: 0,
+  LOWEST: 1,
+  LOW: 10,
+  LOW_MEDIUM: 25,
+  MEDIUM: 50,
+  MEDIUM_HIGH: 65,
+  HIGH: 80,
+  VERY_HIGH: 90,
+  HIGHEST: 100,
 };
 
 export type ExposureKey = {


### PR DESCRIPTION
It looks like these risk levels are now online in the documentation 😄 

- [invalid](https://developer.apple.com/documentation/exposurenotification/enrisklevel/enrisklevelinvalid?language=objc)
- [lowest](https://developer.apple.com/documentation/exposurenotification/enrisklevel/enrisklevellowest?language=objc)
- [low](https://developer.apple.com/documentation/exposurenotification/enrisklevel/enrisklevellow?language=objc)
- [low-medium](https://developer.apple.com/documentation/exposurenotification/enrisklevel/enrisklevellowmedium?language=objc)
- [medium](https://developer.apple.com/documentation/exposurenotification/enrisklevel/enrisklevelmedium?language=objc)
- [medium-high](https://developer.apple.com/documentation/exposurenotification/enrisklevel/enrisklevelmediumhigh?language=objc)
- [high](https://developer.apple.com/documentation/exposurenotification/enrisklevel/enrisklevelhigh?language=objc)
- [very-high](https://developer.apple.com/documentation/exposurenotification/enrisklevel/enrisklevelveryhigh?language=objc)
- [highest](https://developer.apple.com/documentation/exposurenotification/enrisklevel/enrisklevelhighest?language=objc)